### PR TITLE
First iteration of refactoring reflection mechanisms for custom routing

### DIFF
--- a/core/batch_test.go
+++ b/core/batch_test.go
@@ -101,7 +101,7 @@ func TestSaveToBatchWithWrongArgs(t *testing.T) {
 	idBytes := [16]byte(uuid.New())
 	mockStub.MockInit(hex.EncodeToString(idBytes[:]), [][]byte{config})
 
-	err := applyConfig(&chainCode.contract, mockStub, config)
+	err := applyConfig(chainCode.contract, mockStub, config)
 	require.NoError(t, err)
 
 	mockStub.TxID = testEncodedTxID
@@ -155,7 +155,7 @@ func TestSaveToBatchWithSignedArgs(t *testing.T) {
 	idBytes := [16]byte(uuid.New())
 	mockStub.MockInit(hex.EncodeToString(idBytes[:]), [][]byte{config})
 
-	err := applyConfig(&chainCode.contract, mockStub, config)
+	err := applyConfig(chainCode.contract, mockStub, config)
 	require.NoError(t, err)
 
 	mockStub.TxID = testEncodedTxID
@@ -211,7 +211,7 @@ func TestSaveToBatchWithWrongSignedArgs(t *testing.T) {
 	idBytes := [16]byte(uuid.New())
 	mockStub.MockInit(hex.EncodeToString(idBytes[:]), [][]byte{[]byte(config)})
 
-	err := applyConfig(&chainCode.contract, mockStub, []byte(config))
+	err := applyConfig(chainCode.contract, mockStub, []byte(config))
 	require.NoError(t, err)
 
 	mockStub.TxID = testEncodedTxID
@@ -272,7 +272,7 @@ func TestSaveToBatchWrongFnName(t *testing.T) {
 	}
 	cfgBytes, _ := protojson.Marshal(cfg)
 
-	err = applyConfig(&chainCode.contract, ms, cfgBytes)
+	err = applyConfig(chainCode.contract, ms, cfgBytes)
 	require.NoError(t, err)
 
 	chainCode.methods, err = parseContractMethods(chainCode.contract)
@@ -320,7 +320,7 @@ func SaveAndLoadToBatchTest(t *testing.T, ser *serieBatches, args []string) {
 	rsp := ms.MockInit(hex.EncodeToString(idBytes[:]), [][]byte{cfgBytes})
 	require.Equal(t, int32(shim.OK), rsp.GetStatus(), rsp.GetMessage())
 
-	err = applyConfig(&chainCode.contract, ms, cfgBytes)
+	err = applyConfig(chainCode.contract, ms, cfgBytes)
 	require.NoError(t, err)
 
 	ms.TxID = testEncodedTxID
@@ -445,7 +445,7 @@ func BatchExecuteTest(t *testing.T, ser *serieBatchExecute, args []string) peer.
 	rsp := ms.MockInit(hex.EncodeToString(idBytes[:]), [][]byte{cfgBytes})
 	require.Equal(t, int32(shim.OK), rsp.GetStatus())
 
-	err = applyConfig(&chainCode.contract, ms, cfgBytes)
+	err = applyConfig(chainCode.contract, ms, cfgBytes)
 	require.NoError(t, err)
 
 	ms.TxID = testEncodedTxID
@@ -517,7 +517,7 @@ func TestBatchedTxExecute(t *testing.T) {
 	rsp := ms.MockInit(hex.EncodeToString(idBytes[:]), [][]byte{cfgBytes})
 	require.Equal(t, int32(shim.OK), rsp.GetStatus())
 
-	err = applyConfig(&chainCode.contract, ms, cfgBytes)
+	err = applyConfig(chainCode.contract, ms, cfgBytes)
 	require.NoError(t, err)
 
 	chainCode.methods, err = parseContractMethods(chainCode.contract)

--- a/core/batch_test.go
+++ b/core/batch_test.go
@@ -29,7 +29,7 @@ const (
 var (
 	testChaincodeName = "chaincode"
 
-	argsForTestFnWithFive          = []string{"4aap@*", "hyexc566", "kiubfvr$", ";3vkpp", "g?otov;", "!djski", "gfgt^"}
+	argsForTestFnWithFive          = []string{"4aap@*", "hyexc566", "kiubfvr$", ";3vkpp", "g?otov;"}
 	argsForTestFnWithSignedTwoArgs = []string{"1", "arg1"}
 
 	sender = &proto.Address{

--- a/core/multiswap.go
+++ b/core/multiswap.go
@@ -35,7 +35,11 @@ func (cc *ChainCode) multiSwapDoneHandler(
 		return shim.Error("handling multi-swap done failed, " + ErrMultiSwapDisabled.Error())
 	}
 
-	contract := copyContractWithConfig(traceCtx, cc.contract, stub, cfgBytes).(BaseContractInterface)
+	contract, ok := copyContractWithConfig(traceCtx, cc.contract, stub, cfgBytes).(BaseContractInterface)
+	if !ok {
+		return shim.Error("unsupported contract type")
+	}
+
 	return multiswap.UserDone(contract, args[0], args[1])
 }
 

--- a/core/multiswap.go
+++ b/core/multiswap.go
@@ -35,8 +35,7 @@ func (cc *ChainCode) multiSwapDoneHandler(
 		return shim.Error("handling multi-swap done failed, " + ErrMultiSwapDisabled.Error())
 	}
 
-	_, contract := copyContractWithConfig(traceCtx, cc.contract, stub, cfgBytes)
-
+	contract := copyContractWithConfig(traceCtx, cc.contract, stub, cfgBytes).(BaseContractInterface)
 	return multiswap.UserDone(contract, args[0], args[1])
 }
 

--- a/core/reflect.go
+++ b/core/reflect.go
@@ -24,14 +24,14 @@ type In struct {
 
 // Fn is a struct for function
 type Fn struct {
-	Name      string
-	FName     string
-	fn        reflect.Value
-	query     bool
-	noBatch   bool
-	needsAuth bool
-	in        []In
-	out       bool
+	Name           string
+	FName          string
+	fn             reflect.Value
+	query          bool
+	noBatch        bool
+	needsAuth      bool
+	in             []In
+	hasOutputValue bool
 }
 
 func (f *Fn) getInputs(method reflect.Method) error {
@@ -211,7 +211,7 @@ func parseContractMethods(in BaseContractInterface) (ContractMethods, error) {
 			return nil, err
 		}
 
-		out[functionName].out, err = checkOut(method)
+		out[functionName].hasOutputValue, err = checkOut(method)
 		if err != nil {
 			return nil, err
 		}

--- a/core/reflect.go
+++ b/core/reflect.go
@@ -173,22 +173,25 @@ func parseContractMethods(in BaseContractInterface) (ContractMethods, error) {
 			continue
 		}
 
-		var (
-			methodName          = method.Name
-			methodNameTruncated string
-		)
-
+		var methodNameTruncated string
 		switch {
-		case len(methodName) > 4 && methodName[0:4] == noBatchPrefix:
+		case strings.HasPrefix(method.Name, txPrefix):
+			methodNameTruncated = strings.TrimPrefix(method.Name, txPrefix)
+
+		case strings.HasPrefix(method.Name, noBatchPrefix):
 			nb = true
-			methodNameTruncated = methodName[4:]
-		case len(methodName) > 5 && methodName[0:5] == queryPrefix:
+			methodNameTruncated = strings.TrimPrefix(method.Name, noBatchPrefix)
+
+		case strings.HasPrefix(method.Name, queryPrefix):
 			query = true
 			nb = true
-			methodNameTruncated = methodName[5:]
-		case len(methodName) > 2 && methodName[0:2] == txPrefix:
-			methodNameTruncated = methodName[2:]
+			methodNameTruncated = strings.TrimPrefix(method.Name, queryPrefix)
+
 		default:
+			continue
+		}
+
+		if len(methodNameTruncated) == 0 {
 			continue
 		}
 
@@ -199,7 +202,7 @@ func parseContractMethods(in BaseContractInterface) (ContractMethods, error) {
 		}
 
 		out[functionName] = &Fn{
-			Name:    methodName,
+			Name:    method.Name,
 			FName:   functionName,
 			fn:      method.Func,
 			noBatch: nb,

--- a/core/reflect/call.go
+++ b/core/reflect/call.go
@@ -14,10 +14,10 @@ import (
 
 // Error types.
 var (
-	ErrMethodNotFound          = errors.New("method not found")
 	ErrIncorrectArgumentCount  = errors.New("incorrect number of arguments")
-	ErrUnsupportedArgumentType = errors.New("unsupported argument type")
 	ErrInvalidArgumentValue    = errors.New("invalid argument value")
+	ErrMethodNotFound          = errors.New("method not found")
+	ErrUnsupportedArgumentType = errors.New("unsupported argument type")
 )
 
 // Call invokes a specified method on a given value using reflection. The method to be invoked is identified by its name.
@@ -124,8 +124,6 @@ func valueOf(s string, t reflect.Type) (reflect.Value, error) {
 		outValue = argValue.Elem() // assign the element of the pointer to the return value
 	}
 
-	argInterface := argValue.Interface()
-
 	// Trying to check if the argument type is a string or *string.
 	switch {
 	case argType.Kind() == reflect.String:
@@ -136,6 +134,8 @@ func valueOf(s string, t reflect.Type) (reflect.Value, error) {
 		argValue.Elem().SetString(string(argRaw))
 		return outValue, nil
 	}
+
+	argInterface := argValue.Interface()
 
 	// Check if the argument is a valid json string.
 	if json.Valid(argRaw) {

--- a/core/reflect/call.go
+++ b/core/reflect/call.go
@@ -93,7 +93,7 @@ func value(s string, t reflect.Type) (reflect.Value, error) {
 
 	argInterface := argValue.Interface()
 
-	// Trying to check if the agrument type is a string or *string.
+	// Trying to check if the argument type is a string or *string.
 	switch {
 	case argType.Kind() == reflect.String:
 		outValue.SetString(string(argRaw))

--- a/core/reflect/call.go
+++ b/core/reflect/call.go
@@ -1,0 +1,150 @@
+package reflect
+
+import (
+	"encoding"
+	"encoding/gob"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// Error types.
+var (
+	ErrMethodNotFound          = errors.New("method not found")
+	ErrIncorrectArgumentCount  = errors.New("incorrect number of arguments")
+	ErrUnsupportedArgumentType = errors.New("unsupported argument type")
+	ErrInvalidArgumentValue    = errors.New("invalid argument value")
+)
+
+// Call invokes a method on a given value with the provided arguments and returns the output of the method.
+//
+// Parameters:
+// - v: The value on which the method is invoked.
+// - method: The name of the method to be invoked.
+// - args: The arguments to be passed to the method.
+//
+// Returns:
+// - []any: The output of the method as a slice of any type.
+// - error: An error if the method is not found or if the number of arguments is incorrect.
+func Call(v any, method string, args ...string) ([]any, error) {
+	inputVal := reflect.ValueOf(v)
+
+	methodVal := inputVal.MethodByName(method)
+	if !methodVal.IsValid() {
+		return nil, fmt.Errorf("%w: %s", ErrMethodNotFound, method)
+	}
+
+	methodType := methodVal.Type()
+	if methodType.NumIn() != len(args) {
+		return nil, fmt.Errorf(
+			"%w: found %d but expected %d: call %s",
+			ErrIncorrectArgumentCount,
+			len(args),
+			methodType.NumIn(),
+			method,
+		)
+	}
+
+	var (
+		in  = make([]reflect.Value, len(args))
+		err error
+	)
+	for i, arg := range args {
+		if in[i], err = value(arg, methodType.In(i)); err != nil {
+			return nil, fmt.Errorf("%w: call %s", err, method)
+		}
+	}
+
+	output := make([]any, methodType.NumOut())
+	for i, res := range methodVal.Call(in) {
+		output[i] = res.Interface()
+	}
+
+	return output, nil
+}
+
+func value(s string, t reflect.Type) (reflect.Value, error) {
+	var (
+		argRaw     = []byte(s)
+		argType    = t
+		argPointer = t.Kind() == reflect.Pointer
+	)
+
+	// If the type is a pointer, create a new instance of the element type
+	// and assign it to the pointer. Otherwise, create a new instance of the
+	// type and assign it to the element of the newly created pointer.
+	// This is necessary because we can't call json.Unmarshal directly on a
+	// pointer.
+	var (
+		argValue reflect.Value
+		outValue reflect.Value
+	)
+	if argPointer {
+		argValue = reflect.New(t.Elem()) // create a new instance of the element type
+		outValue = argValue              // assign the pointer to the return value
+	} else {
+		argValue = reflect.New(t)  // create a new instance of the type
+		outValue = argValue.Elem() // assign the element of the pointer to the return value
+	}
+
+	argInterface := argValue.Interface()
+
+	// Trying to check if the agrument type is a string or *string.
+	switch {
+	case argType.Kind() == reflect.String:
+		outValue.SetString(string(argRaw))
+		return outValue, nil
+
+	case argPointer && argType.Elem().Kind() == reflect.String:
+		argValue.Elem().SetString(string(argRaw))
+		return outValue, nil
+	}
+
+	// Check if the argument is a valid json string.
+	if json.Valid(argRaw) {
+		var err error
+		if protoMessage, ok := argInterface.(proto.Message); ok {
+			err = protojson.Unmarshal(argRaw, protoMessage)
+		} else {
+			err = json.Unmarshal(argRaw, argInterface)
+		}
+		if err == nil {
+			return outValue, nil
+		}
+	}
+
+	// Trying to use the encoding.TextUnmarshaler interface.
+	if unmarshaler, ok := argInterface.(encoding.TextUnmarshaler); ok {
+		if err := unmarshaler.UnmarshalText(argRaw); err == nil {
+			return outValue, nil
+		}
+	}
+
+	// Trying to use the proto.Message interface.
+	if protoMessage, ok := argInterface.(proto.Message); ok {
+		if err := proto.Unmarshal(argRaw, protoMessage); err == nil {
+			return outValue, nil
+		}
+	}
+
+	// Trying to use the encoding.BinaryUnmarshaler interface.
+	if unmarshaler, ok := argInterface.(encoding.BinaryUnmarshaler); ok {
+		if err := unmarshaler.UnmarshalBinary(argRaw); err == nil {
+			return outValue, nil
+		}
+	}
+
+	// Trying to use the gob.GobDecoder interface.
+	if decoder, ok := argInterface.(gob.GobDecoder); ok {
+		if err := decoder.GobDecode(argRaw); err == nil {
+			return outValue, nil
+		}
+	}
+
+	// Unsupported type.
+	return outValue, fmt.Errorf("%w: type %s", ErrUnsupportedArgumentType, argType.String())
+}

--- a/core/reflect/call_test.go
+++ b/core/reflect/call_test.go
@@ -1,0 +1,206 @@
+package reflect
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/anoideaopen/foundation/proto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	pb "google.golang.org/protobuf/proto"
+)
+
+type TestStruct2 struct{}
+
+func (t *TestStruct2) Method1(ts *time.Time) {
+	fmt.Printf("ts: %v\n", ts)
+}
+
+func (t *TestStruct2) Method2(ts time.Time) {
+	fmt.Printf("ts: %v\n", ts)
+}
+
+func (t *TestStruct2) Method3(a *proto.Address) string {
+	fmt.Printf("a: %+v\n", a)
+	return a.AddrString()
+}
+
+func (t *TestStruct2) Method4(in float64) {
+	fmt.Printf("in: %+v\n", in)
+}
+
+func (t *TestStruct2) Method5(in []float64) {
+	fmt.Printf("in: %+v\n", in)
+}
+
+func (t *TestStruct2) Method6(in *big.Int) {
+	fmt.Printf("in: %+v\n", in)
+}
+
+func (t *TestStruct2) Method7(in string) {
+	fmt.Printf("in: %+v\n", in)
+}
+
+func (t *TestStruct2) Method8(in *string) {
+	fmt.Printf("in: %+v\n", in)
+}
+
+func (t *TestStruct2) Method9(in *int) {
+	fmt.Printf("in: %+v\n", in)
+}
+
+func TestCall(t *testing.T) {
+	input := &TestStruct2{}
+
+	a := &proto.Address{
+		UserID:       "1234",
+		Address:      []byte{1, 2, 3, 4},
+		IsIndustrial: true,
+		IsMultisig:   false,
+	}
+	aJSON, _ := protojson.Marshal(a)
+	aRaw, _ := pb.Marshal(a)
+
+	nowBinary, _ := time.Now().MarshalBinary()
+	valueGOB, _ := big.NewInt(42).GobEncode()
+
+	tests := []struct {
+		name      string
+		method    string
+		args      []string
+		wantLen   int
+		wantErr   bool
+		wantValue any
+	}{
+		{
+			name:    "MethodX unsupported method",
+			method:  "MethodX",
+			args:    []string{},
+			wantLen: 0,
+			wantErr: true,
+		},
+		{
+			name:    "Method1 with correct time format",
+			method:  "Method1",
+			args:    []string{time.Now().Format(time.RFC3339)},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "Method1 with correct binary time format",
+			method:  "Method1",
+			args:    []string{string(nowBinary)},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "Method2 with correct time format",
+			method:  "Method2",
+			args:    []string{time.Now().Format(time.RFC3339)},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:      "Method3 with JSON",
+			method:    "Method3",
+			args:      []string{string(aJSON)},
+			wantLen:   1,
+			wantErr:   false,
+			wantValue: a.AddrString(),
+		},
+		{
+			name:    "Method3 with Protobuf",
+			method:  "Method3",
+			args:    []string{string(aRaw)},
+			wantLen: 1,
+			wantErr: false,
+		},
+		{
+			name:    "Method4 with float input",
+			method:  "Method4",
+			args:    []string{"1234.5678"},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "Method5 with array input",
+			method:  "Method5",
+			args:    []string{"[1234.5678, 1234.5678]"},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "Method5 with incorrect format",
+			method:  "Method5",
+			args:    []string{"1234.5678, 1234.5678"},
+			wantLen: 0,
+			wantErr: true,
+		},
+		{
+			name:    "Method5 with incorrect args count",
+			method:  "Method5",
+			args:    []string{"1234.5678", "1234.5678"},
+			wantLen: 0,
+			wantErr: true,
+		},
+		{
+			name:    "Method6 with big.Int input",
+			method:  "Method6",
+			args:    []string{"1234"},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "Method6 with incorrect value type big.Int",
+			method:  "Method6",
+			args:    []string{"1234.5678"},
+			wantLen: 0,
+			wantErr: true,
+		},
+		{
+			name:    "Method6 with GOB input",
+			method:  "Method6",
+			args:    []string{string(valueGOB)},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "Method7 with string input",
+			method:  "Method7",
+			args:    []string{"1234"},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "Method8 with string input",
+			method:  "Method8",
+			args:    []string{"1234"},
+			wantLen: 0,
+			wantErr: false,
+		},
+		{
+			name:    "Method9 with int input",
+			method:  "Method9",
+			args:    []string{"1234"},
+			wantLen: 0,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := Call(input, tt.method, tt.args...)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Len(t, resp, tt.wantLen)
+			if tt.wantValue != nil {
+				require.Equal(t, tt.wantValue, resp[0])
+			}
+		})
+	}
+}

--- a/core/reflect/call_test.go
+++ b/core/reflect/call_test.go
@@ -8,11 +8,22 @@ import (
 	"time"
 
 	"github.com/anoideaopen/foundation/core/types"
+	corebig "github.com/anoideaopen/foundation/core/types/big"
 	"github.com/anoideaopen/foundation/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
 	pb "google.golang.org/protobuf/proto"
 )
+
+type TestMultiSwapAsset struct {
+	Group   string       `json:"group,omitempty"`
+	Amount  *corebig.Int `json:"amount,omitempty"`
+	Amount2 *big.Int     `json:"amount2,omitempty"`
+}
+
+type TestMultiSwapAssets struct {
+	Assets []*TestMultiSwapAsset `json:"assets,omitempty"`
+}
 
 type TestStructForCall struct{}
 
@@ -67,6 +78,20 @@ func (t *TestStructForCall) Method11(in *types.MultiSwapAssets) *types.MultiSwap
 	return in
 }
 
+func (t *TestStructForCall) Method12(in TestMultiSwapAssets) TestMultiSwapAssets {
+	for _, a := range in.Assets {
+		fmt.Printf("a: %+v\n", a)
+	}
+	return in
+}
+
+func (t *TestStructForCall) Method13(in *TestMultiSwapAssets) *TestMultiSwapAssets {
+	for _, a := range in.Assets {
+		fmt.Printf("a: %+v\n", a)
+	}
+	return in
+}
+
 func TestCall(t *testing.T) {
 	input := &TestStructForCall{}
 
@@ -80,8 +105,10 @@ func TestCall(t *testing.T) {
 	aRaw, _ := pb.Marshal(a)
 
 	nowBinary, _ := time.Now().MarshalBinary()
+
 	valueGOB, _ := big.NewInt(42).GobEncode()
-	multiswapAssets := types.MultiSwapAssets{
+
+	multiSwapAssets := types.MultiSwapAssets{
 		Assets: []*types.MultiSwapAsset{
 			{
 				Group:  "A",
@@ -93,7 +120,23 @@ func TestCall(t *testing.T) {
 			},
 		},
 	}
-	multiswapAssetsJSON, _ := json.Marshal(multiswapAssets)
+	multiSwapAssetsJSON, _ := json.Marshal(multiSwapAssets)
+
+	testMultiSwapAssets := TestMultiSwapAssets{
+		Assets: []*TestMultiSwapAsset{
+			{
+				Group:   "C",
+				Amount:  corebig.NewInt(1),
+				Amount2: big.NewInt(2),
+			},
+			{
+				Group:   "D",
+				Amount:  corebig.NewInt(3),
+				Amount2: big.NewInt(4),
+			},
+		},
+	}
+	testMultiSwapAssetsJSON, _ := json.Marshal(testMultiSwapAssets)
 
 	tests := []struct {
 		name      string
@@ -219,18 +262,34 @@ func TestCall(t *testing.T) {
 		{
 			name:      "Method10 with a complex MultiSwapAssets input and output",
 			method:    "Method10",
-			args:      []string{string(multiswapAssetsJSON)},
+			args:      []string{string(multiSwapAssetsJSON)},
 			wantLen:   1,
 			wantErr:   false,
-			wantValue: multiswapAssets,
+			wantValue: multiSwapAssets,
 		},
 		{
 			name:      "Method11 with a complex MultiSwapAssets input and output",
 			method:    "Method11",
-			args:      []string{string(multiswapAssetsJSON)},
+			args:      []string{string(multiSwapAssetsJSON)},
 			wantLen:   1,
 			wantErr:   false,
-			wantValue: &multiswapAssets,
+			wantValue: &multiSwapAssets,
+		},
+		{
+			name:      "Method12 with a complex TestMultiSwapAssets input and output",
+			method:    "Method12",
+			args:      []string{string(testMultiSwapAssetsJSON)},
+			wantLen:   1,
+			wantErr:   false,
+			wantValue: testMultiSwapAssets,
+		},
+		{
+			name:      "Method13 with a complex TestMultiSwapAssets input and output",
+			method:    "Method13",
+			args:      []string{string(testMultiSwapAssetsJSON)},
+			wantLen:   1,
+			wantErr:   false,
+			wantValue: &testMultiSwapAssets,
 		},
 	}
 

--- a/core/reflect/call_test.go
+++ b/core/reflect/call_test.go
@@ -12,47 +12,47 @@ import (
 	pb "google.golang.org/protobuf/proto"
 )
 
-type TestStruct2 struct{}
+type TestStructForCall struct{}
 
-func (t *TestStruct2) Method1(ts *time.Time) {
+func (t *TestStructForCall) Method1(ts *time.Time) {
 	fmt.Printf("ts: %v\n", ts)
 }
 
-func (t *TestStruct2) Method2(ts time.Time) {
+func (t *TestStructForCall) Method2(ts time.Time) {
 	fmt.Printf("ts: %v\n", ts)
 }
 
-func (t *TestStruct2) Method3(a *proto.Address) string {
+func (t *TestStructForCall) Method3(a *proto.Address) string {
 	fmt.Printf("a: %+v\n", a)
 	return a.AddrString()
 }
 
-func (t *TestStruct2) Method4(in float64) {
+func (t *TestStructForCall) Method4(in float64) {
 	fmt.Printf("in: %+v\n", in)
 }
 
-func (t *TestStruct2) Method5(in []float64) {
+func (t *TestStructForCall) Method5(in []float64) {
 	fmt.Printf("in: %+v\n", in)
 }
 
-func (t *TestStruct2) Method6(in *big.Int) {
+func (t *TestStructForCall) Method6(in *big.Int) {
 	fmt.Printf("in: %+v\n", in)
 }
 
-func (t *TestStruct2) Method7(in string) {
+func (t *TestStructForCall) Method7(in string) {
 	fmt.Printf("in: %+v\n", in)
 }
 
-func (t *TestStruct2) Method8(in *string) {
+func (t *TestStructForCall) Method8(in *string) {
 	fmt.Printf("in: %+v\n", in)
 }
 
-func (t *TestStruct2) Method9(in *int) {
+func (t *TestStructForCall) Method9(in *int) {
 	fmt.Printf("in: %+v\n", in)
 }
 
 func TestCall(t *testing.T) {
-	input := &TestStruct2{}
+	input := &TestStructForCall{}
 
 	a := &proto.Address{
 		UserID:       "1234",

--- a/core/reflect/call_test.go
+++ b/core/reflect/call_test.go
@@ -1,11 +1,13 @@
 package reflect
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/anoideaopen/foundation/core/types"
 	"github.com/anoideaopen/foundation/proto"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -51,6 +53,20 @@ func (t *TestStructForCall) Method9(in *int) {
 	fmt.Printf("in: %+v\n", in)
 }
 
+func (t *TestStructForCall) Method10(in types.MultiSwapAssets) types.MultiSwapAssets {
+	for _, a := range in.Assets {
+		fmt.Printf("a: %+v\n", a)
+	}
+	return in
+}
+
+func (t *TestStructForCall) Method11(in *types.MultiSwapAssets) *types.MultiSwapAssets {
+	for _, a := range in.Assets {
+		fmt.Printf("a: %+v\n", a)
+	}
+	return in
+}
+
 func TestCall(t *testing.T) {
 	input := &TestStructForCall{}
 
@@ -65,6 +81,19 @@ func TestCall(t *testing.T) {
 
 	nowBinary, _ := time.Now().MarshalBinary()
 	valueGOB, _ := big.NewInt(42).GobEncode()
+	multiswapAssets := types.MultiSwapAssets{
+		Assets: []*types.MultiSwapAsset{
+			{
+				Group:  "A",
+				Amount: "1",
+			},
+			{
+				Group:  "B",
+				Amount: "2",
+			},
+		},
+	}
+	multiswapAssetsJSON, _ := json.Marshal(multiswapAssets)
 
 	tests := []struct {
 		name      string
@@ -186,6 +215,22 @@ func TestCall(t *testing.T) {
 			args:    []string{"1234"},
 			wantLen: 0,
 			wantErr: false,
+		},
+		{
+			name:      "Method10 with a complex MultiSwapAssets input and output",
+			method:    "Method10",
+			args:      []string{string(multiswapAssetsJSON)},
+			wantLen:   1,
+			wantErr:   false,
+			wantValue: multiswapAssets,
+		},
+		{
+			name:      "Method11 with a complex MultiSwapAssets input and output",
+			method:    "Method11",
+			args:      []string{string(multiswapAssetsJSON)},
+			wantLen:   1,
+			wantErr:   false,
+			wantValue: &multiswapAssets,
 		},
 	}
 

--- a/core/swap.go
+++ b/core/swap.go
@@ -38,8 +38,7 @@ func (cc *ChainCode) swapDoneHandler(
 		return shim.Error("handling swap done failed, " + ErrSwapDisabled.Error())
 	}
 
-	_, contract := copyContractWithConfig(traceCtx, cc.contract, stub, cfgBytes)
-
+	contract := copyContractWithConfig(traceCtx, cc.contract, stub, cfgBytes).(BaseContractInterface)
 	return swap.UserDone(contract, args[0], args[1])
 }
 

--- a/core/swap.go
+++ b/core/swap.go
@@ -38,7 +38,11 @@ func (cc *ChainCode) swapDoneHandler(
 		return shim.Error("handling swap done failed, " + ErrSwapDisabled.Error())
 	}
 
-	contract := copyContractWithConfig(traceCtx, cc.contract, stub, cfgBytes).(BaseContractInterface)
+	contract, ok := copyContractWithConfig(traceCtx, cc.contract, stub, cfgBytes).(BaseContractInterface)
+	if !ok {
+		return shim.Error("unsupported contract type")
+	}
+
 	return swap.UserDone(contract, args[0], args[1])
 }
 

--- a/core/types/custom.go
+++ b/core/types/custom.go
@@ -98,6 +98,19 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 	return err
 }
 
+func (a *Address) UnmarshalText(text []byte) error {
+	addr, err := AddrFromBase58Check(string(text))
+	if err != nil {
+		return err
+	}
+
+	a.UserID = addr.UserID
+	a.Address = addr.Address
+	a.IsIndustrial = addr.IsIndustrial
+	a.IsMultisig = addr.IsMultisig
+	return nil
+}
+
 // IsUserIDSame checks if userIDs are the same
 func (a *Address) IsUserIDSame(b *Address) bool {
 	if a.UserID == "" || b.UserID == "" {
@@ -109,6 +122,16 @@ func (a *Address) IsUserIDSame(b *Address) bool {
 // Sender is a wrapper for address
 type Sender struct {
 	addr *Address
+}
+
+func (s *Sender) UnmarshalText(text []byte) error {
+	addr, err := AddrFromBase58Check(string(text))
+	if err != nil {
+		return err
+	}
+
+	s.addr = addr
+	return nil
 }
 
 // NewSenderFromAddr creates sender from address
@@ -128,6 +151,16 @@ func (s *Sender) Equal(addr *Address) bool {
 
 // Hex is a wrapper for []byte
 type Hex []byte
+
+func (h *Hex) UnmarshalText(text []byte) error {
+	value, err := hex.DecodeString(string(text))
+	if err != nil {
+		return err
+	}
+
+	*h = value
+	return nil
+}
 
 // ConvertToCall converts string to hex
 func (h Hex) ConvertToCall(_ shim.ChaincodeStubInterface, in string) (Hex, error) { // stub


### PR DESCRIPTION
In this PR, we have made the following changes:
- Added the `reflect` package, which enables transparent method invocation on any type.
- Integrated `reflect.Call` into the core codebase.
- This now supports ALL basic types, not just those specified in `types/base.go`.
- Removed the necessity for `ConvertToCall`, which might be deprecated in future updates.
- Fixed a bug in unit tests.
- Achieved 100% coverage for the `reflect` package.