### PR TITLE
Added tests for task executor, batch, no batch, bench, multiple task in batch (healthCheck, healthCheckNb)

### DIFF
--- a/mock/task_executor.go
+++ b/mock/task_executor.go
@@ -35,45 +35,102 @@ func NewExecutorRequest(ch string, fn string, args []string, isSignedInvoke bool
 }
 
 func (w *Wallet) ExecuteSignedInvoke(ch string, fn string, args ...string) ([]byte, error) {
-	resp, err := w.TaskExecutor(NewExecutorRequest(ch, fn, args, true))
+	executorRequest := NewExecutorRequest(ch, fn, args, true)
+	resp, err := w.TaskExecutorRequest(ch, executorRequest)
+	if err != nil {
+		return nil, fmt.Errorf("execute signed invoke: %v", err)
+	}
+
+	if len(resp) != 1 {
+		return nil, fmt.Errorf("execute signed invoke failed: expected 1 response, got %d", len(resp))
+	}
+
+	return resp[0].BatchTxEvent.GetResult(), nil
+}
+
+func (w *Wallet) ExecuteNoSignedInvoke(ch string, fn string, args ...string) ([]byte, error) {
+	executorRequest := NewExecutorRequest(ch, fn, args, false)
+	resp, err := w.TaskExecutorRequest(ch, executorRequest)
+	if err != nil {
+		return nil, fmt.Errorf("execute signed invoke: %v", err)
+	}
+
+	if len(resp) != 1 {
+		return nil, fmt.Errorf("execute signed invoke failed: expected 1 response, got %d", len(resp))
+	}
+
+	return resp[0].BatchTxEvent.GetResult(), nil
+}
+
+func (w *Wallet) TaskExecutorRequest(channel string, requests ...ExecutorRequest) ([]ExecutorResponse, error) {
+	tasks := make([]*proto.Task, len(requests))
+	for i, r := range requests {
+		if r.Channel != channel {
+			return nil, fmt.Errorf("channel does not match to request channel")
+		}
+		var args []string
+		if r.IsSignedInvoke {
+			args = w.SignArgs(r.Channel, r.Method, r.Args...)
+		} else {
+			args = r.Args
+		}
+
+		task := &proto.Task{
+			Id:     strconv.FormatInt(rand.Int63(), 10),
+			Method: r.Method,
+			Args:   args,
+		}
+
+		tasks[i] = task
+	}
+
+	batchResponse, err := w.TasksExecutor(channel, tasks)
 	if err != nil {
 		return nil, err
 	}
 
-	return resp.BatchTxEvent.GetResult(), nil
-}
-
-func (w *Wallet) TaskExecutor(r ExecutorRequest) (*ExecutorResponse, error) {
-	err := w.verifyIncoming(r.Channel, r.Method)
+	batchEvent, err := w.fetchBatchEvent(channel)
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify incoming args: %w", err)
+		return nil, err
+	}
+	responseMap := make(map[string]*proto.TxResponse)
+	for _, response := range batchResponse.GetTxResponses() {
+		responseMap[string(response.GetId())] = response
+	}
+	executorResponses := make([]ExecutorResponse, 0)
+	for _, batchTxEvent := range batchEvent.GetEvents() {
+		txResponse, ok := responseMap[string(batchTxEvent.GetId())]
+		if !ok {
+			return nil, fmt.Errorf("could not find response for event %v", batchTxEvent.GetId())
+		}
+
+		if responseErr := txResponse.GetError(); responseErr != nil {
+			return nil, errors.New(responseErr.GetError())
+		}
+		executorResponses = append(executorResponses, ExecutorResponse{
+			TxResponse:   txResponse,
+			BatchTxEvent: batchTxEvent,
+		})
 	}
 
+	return executorResponses, nil
+}
+
+func (w *Wallet) TasksExecutor(channel string, tasks []*proto.Task) (*proto.BatchResponse, error) {
 	// setup creator
 	cert, err := hex.DecodeString(batchRobotCert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode hex string batchRobotCert: %w", err)
 	}
-	w.ledger.stubs[r.Channel].SetCreator(cert)
+	w.ledger.stubs[channel].SetCreator(cert)
 
-	var args []string
-	if r.IsSignedInvoke {
-		args, _ = w.sign(r.Method, r.Channel, r.Args...)
-	}
-
-	task := &proto.Task{
-		Id:     strconv.FormatInt(rand.Int63(), 10),
-		Method: r.Method,
-		Args:   args,
-	}
-
-	bytes, err := pb.Marshal(&proto.ExecuteTasksRequest{Tasks: []*proto.Task{task}})
+	bytes, err := pb.Marshal(&proto.ExecuteTasksRequest{Tasks: tasks})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal tasks ExecuteTasksRequest: %w", err)
 	}
 
 	// do invoke chaincode
-	peerResponse, err := w.ledger.doInvokeWithPeerResponse(r.Channel, txIDGen(), core.ExecuteTasks, string(bytes))
+	peerResponse, err := w.ledger.doInvokeWithPeerResponse(channel, txIDGen(), core.ExecuteTasks, string(bytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to invoke method %s: %w", core.ExecuteTasks, err)
 	}
@@ -82,60 +139,24 @@ func (w *Wallet) TaskExecutor(r ExecutorRequest) (*ExecutorResponse, error) {
 		return nil, fmt.Errorf("failed to invoke method %s, status: '%v', message: '%s'", core.ExecuteTasks, peerResponse.GetStatus(), peerResponse.GetMessage())
 	}
 
-	var batchResponse proto.BatchResponse
-	err = pb.Unmarshal(peerResponse.GetPayload(), &batchResponse)
+	batchResponse := &proto.BatchResponse{}
+	err = pb.Unmarshal(peerResponse.GetPayload(), batchResponse)
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal BatchResponse: %w", err)
 	}
 
-	batchTxEvent, err := w.getEventByID(r.Channel, task.GetId())
-	if err != nil {
-		return nil, err
-	}
-
-	txResponse, err := getTxResponseByID(&batchResponse, task.GetId())
-	if err != nil {
-		return nil, err
-	}
-
-	if responseErr := txResponse.GetError(); responseErr != nil {
-		return nil, errors.New(responseErr.GetError())
-	}
-
-	return &ExecutorResponse{
-		TxResponse:   txResponse,
-		BatchTxEvent: batchTxEvent,
-	}, nil
+	return batchResponse, nil
 }
 
-func (w *Wallet) getEventByID(channel string, id string) (*proto.BatchTxEvent, error) {
+func (w *Wallet) fetchBatchEvent(channel string) (*proto.BatchEvent, error) {
 	e := <-w.ledger.stubs[channel].ChaincodeEventsChannel
 	if e.GetEventName() == core.ExecuteTasksEvent {
-		batchEvent := proto.BatchEvent{}
-		err := pb.Unmarshal(e.GetPayload(), &batchEvent)
+		batchEvent := &proto.BatchEvent{}
+		err := pb.Unmarshal(e.GetPayload(), batchEvent)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal BatchEvent: %w", err)
 		}
-		for _, ev := range batchEvent.GetEvents() {
-			if string(ev.GetId()) == id {
-				return ev, nil
-			}
-		}
+		return batchEvent, nil
 	}
-	return nil, fmt.Errorf("failed to find event %s by id %s", core.ExecuteTasksEvent, id)
-}
-
-func getTxResponseByID(
-	batchResponse *proto.BatchResponse,
-	id string,
-) (
-	*proto.TxResponse,
-	error,
-) {
-	for _, response := range batchResponse.GetTxResponses() {
-		if string(response.GetId()) == id {
-			return response, nil
-		}
-	}
-	return nil, fmt.Errorf("failed to find response by id %s", id)
+	return nil, fmt.Errorf("failed to find event %s", core.ExecuteTasksEvent)
 }

--- a/mock/task_executor.go
+++ b/mock/task_executor.go
@@ -1,7 +1,6 @@
 package mock
 
 import (
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -117,13 +116,6 @@ func (w *Wallet) TaskExecutorRequest(channel string, requests ...ExecutorRequest
 }
 
 func (w *Wallet) TasksExecutor(channel string, tasks []*proto.Task) (*proto.BatchResponse, error) {
-	// setup creator
-	cert, err := hex.DecodeString(batchRobotCert)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode hex string batchRobotCert: %w", err)
-	}
-	w.ledger.stubs[channel].SetCreator(cert)
-
 	bytes, err := pb.Marshal(&proto.ExecuteTasksRequest{Tasks: tasks})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal tasks ExecuteTasksRequest: %w", err)

--- a/mock/task_executor.go
+++ b/mock/task_executor.go
@@ -38,7 +38,7 @@ func (w *Wallet) ExecuteSignedInvoke(ch string, fn string, args ...string) ([]by
 	executorRequest := NewExecutorRequest(ch, fn, args, true)
 	resp, err := w.TaskExecutorRequest(ch, executorRequest)
 	if err != nil {
-		return nil, fmt.Errorf("execute signed invoke: %v", err)
+		return nil, fmt.Errorf("execute signed invoke: %w", err)
 	}
 
 	if len(resp) != 1 {
@@ -52,11 +52,11 @@ func (w *Wallet) ExecuteNoSignedInvoke(ch string, fn string, args ...string) ([]
 	executorRequest := NewExecutorRequest(ch, fn, args, false)
 	resp, err := w.TaskExecutorRequest(ch, executorRequest)
 	if err != nil {
-		return nil, fmt.Errorf("execute signed invoke: %v", err)
+		return nil, fmt.Errorf("execute no signed invoke: %w", err)
 	}
 
 	if len(resp) != 1 {
-		return nil, fmt.Errorf("execute signed invoke failed: expected 1 response, got %d", len(resp))
+		return nil, fmt.Errorf("execute no signed invoke failed: expected 1 response, got %d", len(resp))
 	}
 
 	return resp[0].BatchTxEvent.GetResult(), nil
@@ -66,7 +66,7 @@ func (w *Wallet) TaskExecutorRequest(channel string, requests ...ExecutorRequest
 	tasks := make([]*proto.Task, len(requests))
 	for i, r := range requests {
 		if r.Channel != channel {
-			return nil, fmt.Errorf("channel does not match to request channel")
+			return nil, fmt.Errorf("common tasks channel '%s' does not match to request channel '%s'", channel, r.Channel)
 		}
 		var args []string
 		if r.IsSignedInvoke {

--- a/mock/wallet.go
+++ b/mock/wallet.go
@@ -381,6 +381,11 @@ func (w *Wallet) SignArgs(ch, fn string, args ...string) []string {
 	return resp
 }
 
+func (w *Wallet) WithNonceSignArgs(ch, fn string, nonce string, args ...string) []string {
+	resp, _ := w.signWithNonce(fn, ch, nonce, args...)
+	return resp
+}
+
 // BatchedInvoke invokes a function on the ledger
 func (w *Wallet) BatchedInvoke(ch, fn string, args ...string) (string, TxResponse) {
 	if err := w.verifyIncoming(ch, fn); err != nil {
@@ -446,6 +451,11 @@ func (w *Wallet) sign(fn, ch string, args ...string) ([]string, string) {
 
 	// Generation of nonce based on current time in milliseconds.
 	nonce := strconv.FormatInt(time.Now().UnixNano()/1000000, 10)
+
+	return w.signWithNonce(fn, ch, nonce, args...)
+}
+
+func (w *Wallet) signWithNonce(fn, ch string, nonce string, args ...string) ([]string, string) {
 
 	// Forming a message for signature, including function name,
 	// empty string (placeholder), channel name, arguments and nonce.

--- a/mock/wallet.go
+++ b/mock/wallet.go
@@ -456,7 +456,6 @@ func (w *Wallet) sign(fn, ch string, args ...string) ([]string, string) {
 }
 
 func (w *Wallet) signWithNonce(fn, ch string, nonce string, args ...string) ([]string, string) {
-
 	// Forming a message for signature, including function name,
 	// empty string (placeholder), channel name, arguments and nonce.
 	publicKey := w.publicKeyBytes()

--- a/test/unit/task_executor_test.go
+++ b/test/unit/task_executor_test.go
@@ -2,9 +2,13 @@ package unit
 
 import (
 	"encoding/json"
+	"math/rand"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/anoideaopen/foundation/mock"
+	"github.com/anoideaopen/foundation/proto"
 	"github.com/anoideaopen/foundation/token"
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stretchr/testify/require"
@@ -56,4 +60,151 @@ func TestGroupTxExecutorEmitAndTransfer(t *testing.T) {
 	user1.PublicKeyBase58 = base58.Encode(user1.PublicKeyEd25519)
 	_, err = user2.ExecuteSignedInvoke("fiat", "accountsTest", user1.Address(), user1.PublicKeyBase58)
 	require.NoError(t, err)
+}
+
+func TestTxExecutorHealthcheck(t *testing.T) {
+	t.Parallel()
+
+	ledger := mock.NewLedger(t)
+	owner := ledger.NewWallet()
+	feeAddressSetter := ledger.NewWallet()
+	feeSetter := ledger.NewWallet()
+	fiat := NewFiatTestToken(token.BaseToken{})
+	fiatConfig := makeBaseTokenConfig("fiat", "FIAT", 8,
+		owner.Address(), feeSetter.Address(), feeAddressSetter.Address(), "", nil)
+	initMsg := ledger.NewCC("fiat", fiat, fiatConfig)
+	require.Empty(t, initMsg)
+
+	_, err := owner.ExecuteSignedInvoke("fiat", "healthCheck")
+	require.NoError(t, err)
+}
+
+func TestTxExecutorHealthcheckNb(t *testing.T) {
+	t.Parallel()
+
+	ledger := mock.NewLedger(t)
+	owner := ledger.NewWallet()
+	feeAddressSetter := ledger.NewWallet()
+	feeSetter := ledger.NewWallet()
+	fiat := NewFiatTestToken(token.BaseToken{})
+	fiatConfig := makeBaseTokenConfig("fiat", "FIAT", 8,
+		owner.Address(), feeSetter.Address(), feeAddressSetter.Address(), "", nil)
+	initMsg := ledger.NewCC("fiat", fiat, fiatConfig)
+	require.Empty(t, initMsg)
+
+	_, err := owner.ExecuteSignedInvoke("fiat", "healthCheckNb")
+	require.NoError(t, err)
+}
+
+func TestTxExecutorMultipleHealthcheckInBatch(t *testing.T) {
+	t.Parallel()
+
+	ledger := mock.NewLedger(t)
+	owner := ledger.NewWallet()
+	feeAddressSetter := ledger.NewWallet()
+	feeSetter := ledger.NewWallet()
+	fiat := NewFiatTestToken(token.BaseToken{})
+	fiatConfig := makeBaseTokenConfig("fiat", "FIAT", 8,
+		owner.Address(), feeSetter.Address(), feeAddressSetter.Address(), "", nil)
+	initMsg := ledger.NewCC("fiat", fiat, fiatConfig)
+	require.Empty(t, initMsg)
+
+	executorRequests := make([]mock.ExecutorRequest, 0)
+	countRequestsInBatch := 100
+	for i := 0; i < countRequestsInBatch/2; i++ {
+		request := mock.NewExecutorRequest("fiat", "healthCheck", []string{}, true)
+		executorRequests = append(executorRequests, request)
+	}
+	for i := 0; i < countRequestsInBatch/2; i++ {
+		request := mock.NewExecutorRequest("fiat", "healthCheckNb", []string{}, true)
+		executorRequests = append(executorRequests, request)
+	}
+	resp, err := owner.TaskExecutorRequest("fiat", executorRequests...)
+	require.NoError(t, err)
+
+	require.Len(t, resp, countRequestsInBatch)
+}
+
+type PreparedTask struct {
+	tasks []*proto.Task
+}
+
+func BenchmarkTestGroupTxExecutorEmitAndTransfer(b *testing.B) {
+	b.StopTimer()
+	t := &testing.T{}
+	ledger := mock.NewLedger(t)
+	owner := ledger.NewWallet()
+	feeAddressSetter := ledger.NewWallet()
+	feeSetter := ledger.NewWallet()
+	feeAggregator := ledger.NewWallet()
+
+	fiat := NewFiatTestToken(token.BaseToken{})
+	fiatConfig := makeBaseTokenConfig("fiat", "FIAT", 8,
+		owner.Address(), feeSetter.Address(), feeAddressSetter.Address(), "", nil)
+	initMsg := ledger.NewCC("fiat", fiat, fiatConfig)
+	require.Empty(t, initMsg)
+
+	user1 := ledger.NewWallet()
+
+	_, err := owner.ExecuteSignedInvoke("fiat", "emit", user1.Address(), "9999999999999999")
+	require.NoError(t, err)
+
+	user1.BalanceShouldBe("fiat", 9999999999999999)
+
+	_, err = feeAddressSetter.ExecuteSignedInvoke("fiat", "setFeeAddress", feeAggregator.Address())
+	require.NoError(t, err)
+	_, err = feeSetter.ExecuteSignedInvoke("fiat", "setFee", "FIAT", "500000", "100", "100000")
+	require.NoError(t, err)
+
+	rawMD := feeSetter.Invoke("fiat", "metadata")
+	md := &metadata{}
+	require.NoError(t, json.Unmarshal([]byte(rawMD), md))
+
+	require.Equal(t, "FIAT", md.Fee.Currency)
+	require.Equal(t, "500000", md.Fee.Fee.String())
+	require.Equal(t, "100000", md.Fee.Cap.String())
+	require.Equal(t, "100", md.Fee.Floor.String())
+	require.Equal(t, feeAggregator.Address(), md.Fee.Address)
+
+	// transfer arguments
+	channel := "fiat"
+	transferFn := "transfer"
+	emitAmount := "1"
+	reason := ""
+	countInBatch := 10
+
+	// Artificial delay to update the nonce value.
+	time.Sleep(time.Millisecond * 1)
+	// Generation of nonce based on current time in milliseconds.
+	ms := time.Now().UnixNano() / 1000000
+
+	// prepare arguments for test
+	p := make([]PreparedTask, 0)
+	for i := 0; i < b.N; i++ {
+		var tasks []*proto.Task
+		for i := 0; i < countInBatch; i++ {
+			ms++
+			nonce := strconv.FormatInt(ms, 10)
+			args := []string{ledger.NewWallet().Address(), emitAmount, reason}
+			executorRequest := mock.NewExecutorRequest(channel, transferFn, args, true)
+			if executorRequest.IsSignedInvoke {
+				args = user1.WithNonceSignArgs(executorRequest.Channel, executorRequest.Method, nonce, args...)
+			}
+			task := &proto.Task{
+				Id:     strconv.FormatInt(rand.Int63(), 10),
+				Method: executorRequest.Method,
+				Args:   args,
+			}
+			tasks = append(tasks, task)
+		}
+		p = append(p, PreparedTask{
+			tasks: tasks,
+		})
+	}
+
+	// start test method 'transfer' with prepared arguments
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		user1.TasksExecutor(channel, p[i].tasks)
+	}
 }


### PR DESCRIPTION
**wallet**
- added method for sign args with custom nonce, to prepare test data for benchmark

**added tests:**

- task executor: tasks "healthCheck", "healthCheckNb"
- task executor: task "healthCheckNb"
- task executor: task "healthCheck"

**added benchmark:**
- task executor: transfer (emit balance, prepered transfer tasks with  nonce, signature, and start bench)