### PR TITLE
fix accounting for TokenBalanceAddWithTicker func

### DIFF
--- a/core/ledger/balances.go
+++ b/core/ledger/balances.go
@@ -188,8 +188,8 @@ func TokenBalanceAddWithTicker(
 	if stub, ok := stub.(Accounting); ok {
 		stub.AddAccountingRecord(
 			symbol+separator+token,
-			address,
 			&types.Address{},
+			address,
 			amount,
 			reason,
 		)


### PR DESCRIPTION
There was a mistake in `TokenBalanceAddWithTicker` function. Instead of making accounting record showing balance adding from nil-address to user address it shown balance subtraction from user address to nil-address.