### PR TITLE
metadata_test.go migrated to ChaincodeStub usage

### DIFF
--- a/test/unit/metadata_test.go
+++ b/test/unit/metadata_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"testing"
 
-	ma "github.com/anoideaopen/foundation/mock"
+	"github.com/anoideaopen/foundation/core"
+	"github.com/anoideaopen/foundation/mocks"
+	pbfound "github.com/anoideaopen/foundation/proto"
 	"github.com/anoideaopen/foundation/token"
 	"github.com/stretchr/testify/require"
 )
@@ -12,21 +14,28 @@ import (
 func TestMetadataMethods(t *testing.T) {
 	t.Parallel()
 
-	ledger := ma.NewLedger(t)
-	issuer := ledger.NewWallet()
+	mockStub := mocks.NewMockStub(t)
+
+	issuer, err := mocks.NewUserFoundation(pbfound.KeyType_ed25519)
+	require.Nil(t, err)
 
 	tt := &token.BaseToken{}
 	config := makeBaseTokenConfig("Test Token", "TT", 8,
-		issuer.Address(), "", "", "", nil)
-	initMsg := ledger.NewCC("tt", tt, config)
-	require.Empty(t, initMsg)
+		issuer.AddressBase58Check, "", "", "", nil)
 
-	user1 := ledger.NewWallet()
-	rsp := user1.Invoke("tt", "metadata")
+	cc, err := core.NewCC(tt)
+	require.Nil(t, err)
+
+	mockStub.GetStringArgsReturns([]string{config})
+	cc.Init(mockStub)
+
+	mockStub.GetFunctionAndParametersReturns("metadata", []string{})
+	mockStub.GetStateReturnsOnCall(0, []byte(config), nil)
+	mockStub.GetStateReturnsOnCall(1, []byte{}, nil)
+	resp := cc.Invoke(mockStub)
+	require.Empty(t, resp.GetMessage())
 
 	var meta token.Metadata
-	err := json.Unmarshal([]byte(rsp), &meta)
+	err = json.Unmarshal(resp.GetPayload(), &meta)
 	require.NoError(t, err)
-
-	// require.ElementsMatch(t, tokenMethods, meta.Methods)
 }


### PR DESCRIPTION
metadata_test.go migrated to ChaincodeStub usage